### PR TITLE
Update Vulkan to 1.3.283, install vulkan headers

### DIFF
--- a/build/linux/Dockerfile
+++ b/build/linux/Dockerfile
@@ -11,7 +11,7 @@ RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test && add-apt-repository -y p
 
 # Repository for the Vulkan SDK so that we have the glslc compiler
 RUN wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | apt-key add -
-RUN wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.224-focal.list https://packages.lunarg.com/vulkan/1.3.224/lunarg-vulkan-1.3.224-focal.list
+RUN wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.283-focal.list https://packages.lunarg.com/vulkan/1.3.283/lunarg-vulkan-1.3.283-focal.list
 
 RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | \
 	gpg --dearmor - | \
@@ -21,7 +21,7 @@ RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/nul
 RUN apt-get -yq update && apt-get -yq install cmake=3.28.1-0kitware1ubuntu20.04.1 \
 	ninja-build libopenal-dev libreadline6-dev libpng-dev libjpeg62-dev \
 	liblua5.1-0-dev libjansson-dev libsdl2-dev libfreetype6-dev valgrind g++-9 g++-13 \
-	libvulkan-dev vulkan-validationlayers libvulkan1 python3.8 python3.8-dev libxcb-glx0-dev
+	libvulkan-dev vulkan-headers vulkan-validationlayers libvulkan1 python3.8 python3.8-dev libxcb-glx0-dev
 
 COPY llvm.sh /tmp/llvm.sh
 RUN /tmp/llvm.sh 16 && apt-get -yq install clang-tidy-16 libc++-16-dev libc++abi-16-dev


### PR DESCRIPTION
Version 1.3.224 is no longer available. Bump to the highest available SDK version that still has Focal packages.

Also make sure to install the Vulkan headers. Hopefully this is enough to make it possible to build the Vulkan backend in the CI.

See scp-fs2open/fs2open.github.com#6709 .