### PR TITLE
Install shaderc and glslang-tools for vulkan build

### DIFF
--- a/build/linux/Dockerfile
+++ b/build/linux/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get -yq update && apt-get -yq install \
 	python3.8 python3.8-dev libxcb-glx0-dev
 
 RUN if [ "$TARGETARCH" = "amd64" ]; then apt-get -yq install \
-	libvulkan-dev vulkan-headers vulkan-validationlayers libvulkan1; \
+	libvulkan-dev vulkan-headers vulkan-validationlayers libvulkan1 shaderc glslang-tools; \
 	fi
 
 COPY llvm.sh /tmp/llvm.sh


### PR DESCRIPTION
The fs2open build uses `glslc` for `-DSHADERS_ENABLE_COMPILATION=ON`. The OpenXR build seems to look for `glslangValidator`. Install both their packages.

See https://github.com/scp-fs2open/fs2open.github.com/pull/6709#issuecomment-2875869977 .